### PR TITLE
PODAAC-2553: Fix vulnerabilities based on Snyk scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **PODAAC-2553**
+  - Upgrade aws s3 dependency to com.amazonaws:aws-java-sdk-s3@1.11.660 to fix Snyk errors
 
 ### Deprecated
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-s3</artifactId>
-    <version>1.11.229</version>
+    <version>1.11.660</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>


### PR DESCRIPTION
[Jira ticket](https://jira.jpl.nasa.gov/browse/PODAAC-2553)

Upgraded `com.amazonaws:aws-java-sdk-s3@1.11.229` to `com.amazonaws:aws-java-sdk-s3@1.11.660`

Snyk scan before:

```
➜ snyk test

Testing /Users/skperez/Documents/PO.DAAC/cumulus-cnm-to-granule...

Tested 18 dependencies for known issues, found 48 issues, 48 vulnerable paths.


Issues to fix by upgrading:

  Upgrade com.amazonaws:aws-java-sdk-s3@1.11.229 to com.amazonaws:aws-java-sdk-s3@1.11.660 to fix
  ✗ Directory Traversal [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-31517] in org.apache.httpcomponents:httpclient@4.5.2
    introduced by com.amazonaws:aws-java-sdk-s3@1.11.229 > com.amazonaws:aws-java-sdk-core@1.11.229 > org.apache.httpcomponents:httpclient@4.5.2
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-559106] in com.fasterxml.jackson.core:jackson-databind@2.6.7.1
    introduced by com.amazonaws:aws-java-sdk-s3@1.11.229 > com.amazonaws:aws-java-sdk-core@1.11.229 > com.fasterxml.jackson.core:jackson-databind@2.6.7.1
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72448] in com.fasterxml.jackson.core:jackson-databind@2.6.7.1
    introduced by com.amazonaws:aws-java-sdk-s3@1.11.229 > com.amazonaws:aws-java-sdk-core@1.11.229 > com.fasterxml.jackson.core:jackson-databind@2.6.7.1
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72449] in com.fasterxml.jackson.core:jackson-databind@2.6.7.1
    introduced by com.amazonaws:aws-java-sdk-s3@1.11.229 > com.amazonaws:aws-java-sdk-core@1.11.229 > com.fasterxml.jackson.core:jackson-databind@2.6.7.1
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72450] in com.fasterxml.jackson.core:jackson-databind@2.6.7.1
    introduced by com.amazonaws:aws-java-sdk-s3@1.11.229 > com.amazonaws:aws-java-sdk-core@1.11.229 > com.fasterxml.jackson.core:jackson-databind@2.6.7.1
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72451] in com.fasterxml.jackson.core:jackson-databind@2.6.7.1
    introduced by com.amazonaws:aws-java-sdk-s3@1.11.229 > com.amazonaws:aws-java-sdk-core@1.11.229 > com.fasterxml.jackson.core:jackson-databind@2.6.7.1


Issues with no direct upgrade or patch:
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1009829] in com.fasterxml.jackson.core:jackson-databind@2.6.7.1
    introduced by com.amazonaws:aws-java-sdk-s3@1.11.229 > com.amazonaws:aws-java-sdk-core@1.11.229 > com.fasterxml.jackson.core:jackson-databind@2.6.7.1
  This issue was fixed in versions: 2.9.10.6

...
```

Snyk scan after:

```
➜ snyk test

Testing /Users/skperez/Documents/PO.DAAC/cumulus-cnm-to-granule...

Tested 18 dependencies for known issues, found 42 issues, 42 vulnerable paths.


Issues with no direct upgrade or patch:
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1009829] in com.fasterxml.jackson.core:jackson-databind@2.6.7.3
    introduced by com.amazonaws:aws-java-sdk-s3@1.11.660 > com.amazonaws:aws-java-sdk-core@1.11.660 > com.fasterxml.jackson.core:jackson-databind@2.6.7.3
  This issue was fixed in versions: 2.9.10.6

...
```



There are other vulnerabilities as well, but those seem to have no remediation path
