### PR TITLE
feature/PODAAC-2639: Incorporate 'dataType' in granule objects in the task output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - a build script under /builder directory, and a jenkins job to build and push release to public github.
 - **PODAAC-2547**
    - Added support for filegroups in input CNM message
+- **PODAAC-2639**
+   - Added dataType and version to output message
 ### Changed
 - **PODAAC-2553**
   - Upgrade aws s3 dependency to com.amazonaws:aws-java-sdk-s3@1.11.660 to fix Snyk errors

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-s3</artifactId>
-    <version>1.11.660</version>
+    <version>1.11.893</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>

--- a/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
+++ b/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
@@ -133,6 +133,8 @@ public class CnmToGranuleHandler implements  ITask, RequestHandler<String, Strin
 
 		JsonArray files = new JsonArray();
 		granule.addProperty("granuleId", granuleId);
+		granule.addProperty("version", config.getAsJsonObject("collection").get("version").getAsString());
+		granule.addProperty("dataType", config.getAsJsonObject("collection").get("name").getAsString());
 
 		JsonArray inputFiles = cnmObject.getAsJsonObject("product").getAsJsonArray("files");
 		

--- a/src/test/java/gov/nasa/cumulus/CnmToGranuleHandlerTest.java
+++ b/src/test/java/gov/nasa/cumulus/CnmToGranuleHandlerTest.java
@@ -46,7 +46,8 @@ public class CnmToGranuleHandlerTest
         } catch (IOException e) {
             e.printStackTrace();
         }
-
+        
+        JsonObject inputJson = new JsonParser().parse(input).getAsJsonObject();
         CnmToGranuleHandler c = new CnmToGranuleHandler();
         try {
             String output = c.PerformFunction(input, null);
@@ -55,6 +56,19 @@ public class CnmToGranuleHandlerTest
             JsonElement jelement = new JsonParser().parse(output);
             JsonObject outputKey = jelement.getAsJsonObject().get("output").getAsJsonObject();
             JsonObject granule = outputKey.getAsJsonArray("granules").get(0).getAsJsonObject().getAsJsonObject();
+    
+            assert granule.has("version");
+            assert granule.get("version").getAsString().equals(inputJson.getAsJsonObject("config")
+                    .getAsJsonObject("collection")
+                    .get("version")
+                    .getAsString());
+    
+            assert granule.getAsJsonObject().has("dataType");
+            assert granule.get("dataType").getAsString().equals(inputJson.getAsJsonObject("config")
+                    .getAsJsonObject("collection")
+                    .get("name")
+                    .getAsString());
+							
             assertEquals("product_0001-of-0019", granule.get("granuleId").getAsString());
             JsonArray files = granule.get("files").getAsJsonArray();
             assertEquals(2, files.size());

--- a/src/test/resources/expectedFilegroups.json
+++ b/src/test/resources/expectedFilegroups.json
@@ -2,6 +2,8 @@
   "granules": [
     {
       "granuleId": "HLS.S30.T19XEL.2020116T195901.v1.5",
+      "version": "1",
+      "dataType": "L2_HR_LAKE_AVG",
       "files": [
         {
           "name": "HLS.S30.T19XEL.2020116T195901.v1.5.B08.tif",

--- a/src/test/resources/inputFilegroups.json
+++ b/src/test/resources/inputFilegroups.json
@@ -178,7 +178,7 @@
           "bucket": "protected"
         }
       ],
-      "name": "HLS.S30.T19XEL.2020116T195901.v1.5",
+      "name": "L2_HR_LAKE_AVG",
       "granuleIdExtraction": "^(.*)((\\.cmr\\.xml)|(\\.tif)|(\\.jpg))$",
       "granuleId": "^.*$",
       "dataType": "L2_HR_LAKE_AVG",


### PR DESCRIPTION
[Jira ticket](https://jira.jpl.nasa.gov/browse/PODAAC-2639)

My interpretation of what they are requesting is that each output `granule` should contain two fields: `version` and `dataType`. `version` should come from `config.collection.version` and `dataType` should come from `config.collection.name`