### PR TITLE
release/1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.1] - 2020-11-04
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- **PODAAC-2775**
+  - Upgrade to CMA-java v1.3.2 to fix timeout on large messages.
+### Security
+
 ## [v1.4.0] - 2020-11-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.4.1] - 2020-11-04
+## [v1.4.1] - 2020-11-19
 ### Added
 ### Changed
 ### Deprecated

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-to-granule</artifactId>
-  <version>1.4.0</version>
+  <version>1.4.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-to-granule</name>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 <dependency>
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
 </dependency>
 <dependency>
     <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
## [v1.4.1] - 2020-11-19
### Added
### Changed
### Deprecated
### Removed
### Fixed
- **PODAAC-2775**
  - Upgrade to CMA-java v1.3.2 to fix timeout on large messages.
### Security