### PR TITLE
feature/PODAAC-2572 Added minor changes for converting CNM response to CMA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2020-11-19
+## [Unreleased]
 ### Added
 - **PODAAC-2572**
   - Added functionality to transfer CNMResponse to granules
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **PODAAC-2775**
   - Upgrade to CMA-java v1.3.2 to fix timeout on large messages.
-  
 ### Security
 
 ## [v1.4.0] - 2020-11-04

--- a/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
+++ b/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
@@ -7,7 +7,7 @@ import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import gov.nasa.cumulus.gov.nasa.cumulus.bo.ExtraFileFileds;
+import gov.nasa.cumulus.bo.ExtraFileFields;
 import gov.nasa.cumulus.utils.ResponseUriDecoder;
 import org.apache.commons.io.IOUtils;
 
@@ -193,9 +193,10 @@ public class CnmToGranuleHandler implements  ITask, RequestHandler<String, Strin
 			// to translate CNM Response message to granules.
 			if (isCNMResponseFileObject && ObjectUtils.isNotEmpty(cnmFile.get("uri"))) {
 				ResponseUriDecoder decoder = new ResponseUriDecoder();
-				ExtraFileFileds extra = decoder.process(cnmFile.get("uri").getAsString(), distribution_endpoint);
+				ExtraFileFields extra = decoder.process(cnmFile.get("uri").getAsString(), distribution_endpoint);
 				granuleFile.addProperty("bucket", extra.getBucket());
 				granuleFile.addProperty("filename", extra.getFilename());
+				granuleFile.addProperty("path", extra.getFilepath());
 			}
 
 			files.add(granuleFile);

--- a/src/main/java/gov/nasa/cumulus/bo/ExtraFileFields.java
+++ b/src/main/java/gov/nasa/cumulus/bo/ExtraFileFields.java
@@ -1,8 +1,9 @@
-package gov.nasa.cumulus.gov.nasa.cumulus.bo;
+package gov.nasa.cumulus.bo;
 
-public class ExtraFileFileds {
+public class ExtraFileFields {
     String bucket;
     String filename;
+    String filepath;
 
     public String getBucket() {
         return bucket;
@@ -20,4 +21,11 @@ public class ExtraFileFileds {
         this.filename = filename;
     }
 
+    public String getFilepath() {
+        return filepath;
+    }
+
+    public void setFilepath(String filepath) {
+        this.filepath = filepath;
+    }
 }

--- a/src/main/java/gov/nasa/cumulus/utils/ResponseUriDecoder.java
+++ b/src/main/java/gov/nasa/cumulus/utils/ResponseUriDecoder.java
@@ -1,17 +1,17 @@
 package gov.nasa.cumulus.utils;
 
 import cumulus_message_adapter.message_parser.AdapterLogger;
-import gov.nasa.cumulus.gov.nasa.cumulus.bo.ExtraFileFileds;
+import gov.nasa.cumulus.bo.ExtraFileFields;
 import org.apache.commons.lang3.StringUtils;
 
 public class ResponseUriDecoder {
     String className = this.getClass().getName();
 
-    public ExtraFileFileds process(String uri, String distribution_endpoint) {
+    public ExtraFileFields process(String uri, String distribution_endpoint) {
         uri = StringUtils.trim(uri);
         distribution_endpoint =  StringUtils.trim(distribution_endpoint);
         AdapterLogger.LogInfo(this.className + " uri: " + uri + " distribution_endpoint: " + distribution_endpoint);
-        ExtraFileFileds extra = new ExtraFileFileds();
+        ExtraFileFields extra = new ExtraFileFields();
         // Make sure distribution_endpoint ends with slash, the next step removeIgnoreCase will output
         //  bucket_name/folder_name/xxxx.nc
         if(!StringUtils.endsWith(distribution_endpoint, "/")) {
@@ -23,6 +23,11 @@ public class ResponseUriDecoder {
             bucketFolderFilename = StringUtils.substring(bucketFolderFilename, 1); // remove first character
         String[] array = StringUtils.splitByWholeSeparator(bucketFolderFilename, "/");
         extra.setBucket(array[0]);
+        if(array.length >= 3) { // uri includes bucket, folder and filename at least
+            extra.setFilepath(bucketFolderFilename.substring(bucketFolderFilename.indexOf("/") + 1, bucketFolderFilename.lastIndexOf("/")));
+        } else {
+            extra.setFilepath("");
+        }
         return extra;
     }
 }

--- a/src/test/java/gov/nasa/cumulus/CnmToGranuleHandlerTest.java
+++ b/src/test/java/gov/nasa/cumulus/CnmToGranuleHandlerTest.java
@@ -125,11 +125,13 @@ public class CnmToGranuleHandlerTest
         JsonElement granule = granules.get(0);
         JsonArray files = granule.getAsJsonObject().getAsJsonArray("files");
         JsonElement file1 = files.get(0);
-        assertEquals(file1.getAsJsonObject().get("filename").getAsString(), "s3://dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc");
-        assertEquals(file1.getAsJsonObject().get("bucket").getAsString(), "dyen-cumulus-protected");
+        assertEquals("s3://dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc", file1.getAsJsonObject().get("filename").getAsString());
+        assertEquals("dyen-cumulus-protected", file1.getAsJsonObject().get("bucket").getAsString());
+        assertEquals("JASON-1_L2_OST_GPN_E", file1.getAsJsonObject().get("path").getAsString());
         JsonElement file2 = files.get(1);
-        assertEquals(file2.getAsJsonObject().get("filename").getAsString(), "s3://dyen-cumulus-public/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.cmr.json");
-        assertEquals(file2.getAsJsonObject().get("bucket").getAsString(), "dyen-cumulus-public");
+        assertEquals("s3://dyen-cumulus-public/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.cmr.json", file2.getAsJsonObject().get("filename").getAsString());
+        assertEquals("dyen-cumulus-public", file2.getAsJsonObject().get("bucket").getAsString());
+        assertEquals("JASON-1_L2_OST_GPN_E", file2.getAsJsonObject().get("path").getAsString());
     }
 
 }

--- a/src/test/java/gov/nasa/cumulus/ResponseUriDecoderTest.java
+++ b/src/test/java/gov/nasa/cumulus/ResponseUriDecoderTest.java
@@ -1,6 +1,6 @@
 package gov.nasa.cumulus;
 
-import gov.nasa.cumulus.gov.nasa.cumulus.bo.ExtraFileFileds;
+import gov.nasa.cumulus.bo.ExtraFileFields;
 import gov.nasa.cumulus.utils.ResponseUriDecoder;
 import org.junit.Test;
 
@@ -11,15 +11,17 @@ public class ResponseUriDecoderTest {
     @Test
     public void processTest() {
         ResponseUriDecoder reponseUriDecoder = new ResponseUriDecoder();
-        ExtraFileFileds extra = reponseUriDecoder.process("https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc",
+        ExtraFileFields extra = reponseUriDecoder.process("https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc",
                 "https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/");
-        assertEquals(extra.getFilename(),"s3://dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc");
-        assertEquals(extra.getBucket(),"dyen-cumulus-protected");
+        assertEquals("s3://dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc", extra.getFilename());
+        assertEquals("dyen-cumulus-protected", extra.getBucket());
+        assertEquals("JASON-1_L2_OST_GPN_E", extra.getFilepath());
 
         // test case when distribution_endpoint is NOT ending with slash
-        ExtraFileFileds extra2 = reponseUriDecoder.process("https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc",
+        ExtraFileFields extra2 = reponseUriDecoder.process("https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc",
                 "https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV");
-        assertEquals(extra.getFilename(),"s3://dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc");
-        assertEquals(extra2.getBucket(),"dyen-cumulus-protected");
+        assertEquals("s3://dyen-cumulus-protected/JASON-1_L2_OST_GPN_E/JA1_GPN_2PeP001_003_20020115_070317_20020115_075921.nc", extra2.getFilename());
+        assertEquals("dyen-cumulus-protected", extra2.getBucket());
+        assertEquals("JASON-1_L2_OST_GPN_E", extra2.getFilepath());
     }
 }


### PR DESCRIPTION
### Description

Added some minor changes to David's branch.

### Overview of work done

1. Renamed gov.nasa.cumulus.gov.nasa.cumulus.bo.ExtraFileFileds to gov.nasa.cumulus.bo.ExtraFileFields
2. Added back filepath to ExtraFileFields and use filepath to overwrite path in file object. Before this change path was something like `/uh1lvjdlz1.execute-api.us-west-2.amazonaws.com:9000/DEV/podaac-sndbx-cumulus-public/MODIS_A-JPL-L2P-v2019.0`
3. Swapped parameters in assert statements so expected value is the first parameter and actual is the second.

### Overview of verification done

#### Tested in sandbox:

Testing ingest in sandbox with MODIS_A granule.

Output payload from TranslateMessage step:

```
{
    "granules": [
      {
        "granuleId": "20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0",
        "version": "2019.0",
        "dataType": "MODIS_A-JPL-L2P-v2019.0",
        "files": [
          {
            "name": "20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc",
            "path": "MODIS_A-JPL-L2P-v2019.0",
            "url_path": "https://uh1lvjdlz1.execute-api.us-west-2.amazonaws.com:9000/DEV/podaac-sndbx-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc",
            "bucket": "podaac-sndbx-cumulus-protected",
            "size": 18232098,
            "checksumType": "md5",
            "checksum": "aa5204f125ae83847b3b80fa2e571b00",
            "type": "data",
            "filename": "s3://podaac-sndbx-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc"
          },
          {
            "name": "20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5",
            "path": "MODIS_A-JPL-L2P-v2019.0",
            "url_path": "https://uh1lvjdlz1.execute-api.us-west-2.amazonaws.com:9000/DEV/podaac-sndbx-cumulus-public/MODIS_A-JPL-L2P-v2019.0/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5",
            "bucket": "podaac-sndbx-cumulus-public",
            "size": 98,
            "type": "metadata",
            "filename": "s3://podaac-sndbx-cumulus-public/MODIS_A-JPL-L2P-v2019.0/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5"
          },
          {
            "name": "20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.cmr.json",
            "path": "MODIS_A-JPL-L2P-v2019.0",
            "url_path": "https://uh1lvjdlz1.execute-api.us-west-2.amazonaws.com:9000/DEV/podaac-sndbx-cumulus-public/MODIS_A-JPL-L2P-v2019.0/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.cmr.json",
            "bucket": "podaac-sndbx-cumulus-public",
            "size": 1633,
            "type": "metadata",
            "filename": "s3://podaac-sndbx-cumulus-public/MODIS_A-JPL-L2P-v2019.0/20200101000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.cmr.json"
          }
        ]
      }
    ]
  }
```

