### PR TITLE
Feature/podaac 3208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v1.5.0] - 2021-05-12
 ### Added
 - **PODAAC-3208**
-    - add 'source_bucket' key
+    - Added 'source_bucket' key to granule file
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
 - **Snyk**
-    - Upgrade aws-java-sdk-s3@1.11.955 to com.amazonaws:aws-java-sdk-s3@1.11.1005
+    - Upgrade aws-java-sdk-s3@1.11.955 to com.amazonaws:aws-java-sdk-s3@1.11.1016
+    - Upgrade commons-io:commons-io:2.6 to 2.7
 
 ## [v1.4.3] - 2021-02-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- **PODAAC-3208**
+    - add 'source_bucket' key
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **Snyk**
+    - Upgrade aws-java-sdk-s3@1.11.955 to com.amazonaws:aws-java-sdk-s3@1.11.1005
+
 ## [v1.4.3] - 2021-02-17
 ### Added
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-s3</artifactId>
-    <version>1.11.955</version>
+    <version>1.11.1005</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 <dependency>
     <groupId>commons-io</groupId>
     <artifactId>commons-io</artifactId>
-    <version>2.6</version>
+    <version>2.7</version>
 </dependency>
 <dependency>
     <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-to-granule</artifactId>
-  <version>1.4.3</version>
+  <version>1.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-to-granule</name>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-s3</artifactId>
-    <version>1.11.1005</version>
+    <version>1.11.1016</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-to-granule</artifactId>
-  <version>1.4.3-SNAPSHOT</version>
+  <version>1.4.3</version>
   <packaging>jar</packaging>
 
   <name>cnm-to-granule</name>

--- a/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
+++ b/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
@@ -171,6 +171,8 @@ public class CnmToGranuleHandler implements  ITask, RequestHandler<String, Strin
 			granuleFile.addProperty("path", url_path);
 			granuleFile.addProperty("url_path", cnmFile.get("uri").getAsString());
 			granuleFile.addProperty("bucket", bucket);
+			// PODAAC-3208 - add 'source_bucket' key
+            granuleFile.addProperty("source_bucket", bucket);
 			granuleFile.addProperty("size", cnmFile.get("size").getAsLong());
 			if (cnmFile.has("checksumType")) {
 				granuleFile.addProperty("checksumType", cnmFile.get("checksumType").getAsString());

--- a/src/test/java/gov/nasa/cumulus/CnmToGranuleHandlerTest.java
+++ b/src/test/java/gov/nasa/cumulus/CnmToGranuleHandlerTest.java
@@ -89,6 +89,7 @@ public class CnmToGranuleHandlerTest
                 }
                 assertEquals("L2_HR_LAKE_AVG", fileObj.get("path").getAsString());
                 assertEquals("podaac-dev-cumulus-test-input", fileObj.get("bucket").getAsString());
+                assertEquals("podaac-dev-cumulus-test-input", fileObj.get("source_bucket").getAsString());
             }
         } catch(Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Add 'source_bucket' key to com-to-granule output.
This literally just duplicates line 173 in CnmToGranuleHandler.java and line 91 in the relevant test class to create and populate the 'source_bucket' key, using the already parsed 'bucket' string/information.

SNYK Fixes:
updated aws-java-sdk-s3 to 1.11.1005
updated commons.io to 2.7