### PR TITLE
upgrade to cumulus-message-adatper 1.3.3 to overcome log4J 2.15 below…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-- PODAAC-4046 : upgrade to cumulus-message-adapter 1.3.3 for it is using log4J 2.15 to overcome log4j vulunarability
+- PODAAC-4046 : upgrade to cumulus-message-adapter 1.3.3 for it is using log4J 2.15 to overcome log4j vulnerability
 
 ## [v1.6.0] - 2021-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- PODAAC-4046 : upgrade to cumulus-message-adapter 1.3.3 for it is using log4J 2.15 to overcome log4j vulunarability
+
 ## [v1.6.0] - 2021-12-03
 ### Added
 - **PODAAC-4012**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-- PODAAC-4046 : upgrade to cumulus-message-adapter 1.3.3 for it is using log4J 2.15 to overcome log4j vulnerability
+- PODAAC-4046 : upgrade to cumulus-message-adapter 1.3.4 to overcome log4j vulnerability
 
 ## [v1.6.0] - 2021-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-- PODAAC-4046 : upgrade to cumulus-message-adapter 1.3.4 to overcome log4j vulnerability
+- PODAAC-4046, PODAAC-4095 : upgrade to cumulus-message-adapter 1.3.9 to overcome log4j vulnerability
 
 ## [v1.6.0] - 2021-12-03
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>gov.nasa.earthdata</groupId>
             <artifactId>cumulus-message-adapter</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.4</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>gov.nasa.earthdata</groupId>
             <artifactId>cumulus-message-adapter</artifactId>
-            <version>1.3.2</version>
+            <version>1.3.3</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>gov.nasa.earthdata</groupId>
             <artifactId>cumulus-message-adapter</artifactId>
-            <version>1.3.4</version>
+            <version>1.3.9</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Ticket: [PODAAC-4046](https://jira.jpl.nasa.gov/browse/PODAAC-4046)
and PODAAC-4095

### Description

upgrade to cumulus-message-adatper 1.3.9 to overcome log4J 2.15 below vulnerable issue

### Overview of work done
upgrade version in pom.xml


### Overview of verification done

Integration testing in I&A cloud workflow

#### Tested in SIT:

_Explain how you tested in SIT, if applicable_

## PR checklist:

* [ ] Linted
* [ ] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
