### PR TITLE
PODAAC-4059 Upgrade to cumulus-message-adapter-java 1.3.7 to address log4j vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.5.3] - 2021-12-22
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **PODAAC-4059**
+  - Upgrade to cumulus-message-adapter-java 1.3.7 to address [log4j vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-45105) 
+
 ## [v1.5.2] - 2021-12-15
 ### Added
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-to-granule</artifactId>
-  <version>1.5.2</version>
+  <version>1.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-to-granule</name>
@@ -32,7 +32,7 @@
 <dependency>
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
-  <version>1.3.5</version>
+  <version>1.3.7</version>
 </dependency>
 <dependency>
     <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
## [v1.5.3] - 2021-12-22
### Added
### Changed
### Deprecated
### Removed
### Fixed
### Security
- **PODAAC-4059**
  - Upgrade to cumulus-message-adapter-java 1.3.7 to address [log4j vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-45105) 