### PR TITLE
Release/1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
-### Added
-
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
-- **PODAAC-4353**
-  - Upgrade jackson-databind as well as aws-java-sdk-s3 for Snyk warnings
-  - com.amazonaws:aws-java-sdk-s3@1.12.176 to com.amazonaws:aws-java-sdk-s3@1.12.215
-  
-## [v1.7.0] - 2022-03-15
+## [v1.7.0] - 2022-12-12
 ### Added
 - **PODAAC-4308**
   - Support sftp URI from CNM messages
@@ -29,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Snyk**
   - upgrade aws-java-sdk-s3@1.12.144 to aws-java-sdk-s3@1.12.176
   - manual import jackson-databind@2.13.2 due to @2.12.3 (which has issues) being pulled in by aws-java-sdk-s3 even after version updates
+- **PODAAC-4353**
+  - Upgrade jackson-databind as well as aws-java-sdk-s3 for Snyk warnings
+  - com.amazonaws:aws-java-sdk-s3@1.12.176 to com.amazonaws:aws-java-sdk-s3@1.12.215
 
 ## [v1.6.0] - 2021-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+### Added
+
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **PODAAC-4353**
+  - Upgrade jackson-databind as well as aws-java-sdk-s3 for Snyk warnings
+  - com.amazonaws:aws-java-sdk-s3@1.12.176 to com.amazonaws:aws-java-sdk-s3@1.12.215
+  
 ## [v1.7.0] - 2022-03-15
 ### Added
 - **PODAAC-4308**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.7.0] - 2022-03-15
+### Added
+- **PODAAC-4308**
+  - Support sftp URI from CNM messages
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **Snyk**
+  - upgrade aws-java-sdk-s3@1.12.144 to aws-java-sdk-s3@1.12.176
+  - manual import jackson-databind@2.13.2 due to @2.12.3 (which has issues) being pulled in by aws-java-sdk-s3 even after version updates
+
 ## [v1.6.0] - 2021-12-03
 ### Added
 - **PODAAC-4012**

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>gov.nasa.cumulus</groupId>
     <artifactId>cnm-to-granule</artifactId>
-    <version>1.6.0-alpha.1-SNAPSHOT</version>
+    <version>1.6.0-alpha.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cnm-to-granule</name>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.176</version>
+            <version>1.12.215</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2</version>
+            <version>2.13.2.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>gov.nasa.cumulus</groupId>
     <artifactId>cnm-to-granule</artifactId>
-    <version>1.7.0-alpha.2-SNAPSHOT</version>
+    <version>1.7.0-alpha.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cnm-to-granule</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>gov.nasa.cumulus</groupId>
     <artifactId>cnm-to-granule</artifactId>
-    <version>1.7.0-alpha.3-SNAPSHOT</version>
+    <version>1.7.0-alpha.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cnm-to-granule</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>gov.nasa.cumulus</groupId>
     <artifactId>cnm-to-granule</artifactId>
-    <version>1.6.0-alpha.2-SNAPSHOT</version>
+    <version>1.7.0-alpha.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cnm-to-granule</name>
@@ -37,7 +37,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.144</version>
+            <version>1.12.176</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -54,6 +60,12 @@
             <artifactId>junit</artifactId>
             <version>3.8.1</version>
             <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind, manual pull due to aws-java-sdk-s3 not using fixed version -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>gov.nasa.cumulus</groupId>
     <artifactId>cnm-to-granule</artifactId>
-    <version>1.7.0-alpha.4-SNAPSHOT</version>
+    <version>1.7.0-rc.5</version>
     <packaging>jar</packaging>
 
     <name>cnm-to-granule</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>gov.nasa.cumulus</groupId>
     <artifactId>cnm-to-granule</artifactId>
-    <version>1.7.0-rc.5</version>
+    <version>1.7.0-rc.6</version>
     <packaging>jar</packaging>
 
     <name>cnm-to-granule</name>

--- a/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
+++ b/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
@@ -153,6 +153,8 @@ public class CnmToGranuleHandler implements ITask, RequestHandler<String, String
                 granuleFile = buildS3GranuleFile(cnmFile);
             } else if (StringUtils.beginsWithIgnoreCase(uri, "https://")) {
                 granuleFile = buildHttpsGranuleFile(cnmFile);
+            } else if (StringUtils.beginsWithIgnoreCase(uri, "sftp://")) {
+                granuleFile = buildSftpGranuleFile(cnmFile);
             }
             files.add(granuleFile);
         }
@@ -218,6 +220,27 @@ public class CnmToGranuleHandler implements ITask, RequestHandler<String, String
         JsonObject granuleFile = new JsonObject();
         granuleFile.addProperty("name", cnmFile.get("name").getAsString());//
         granuleFile.addProperty("path", url_path);//
+        granuleFile.addProperty("size", cnmFile.get("size").getAsLong());
+        if (cnmFile.has("checksumType")) {
+            granuleFile.addProperty("checksumType", cnmFile.get("checksumType").getAsString());
+        }
+        if (cnmFile.has("checksum")) {
+            granuleFile.addProperty("checksum", cnmFile.get("checksum").getAsString());
+        }
+        granuleFile.addProperty("type", cnmFile.get("type").getAsString());
+        return granuleFile;
+    }
+
+    public JsonObject buildSftpGranuleFile(JsonObject cnmFile){
+        String uri = StringUtils.trim(cnmFile.get("uri").getAsString());
+        AdapterLogger.LogInfo(this.className + " uri: " + uri);
+        String path = uri.replace("sftp://", "");
+        String url_path = path.substring(path.indexOf("/") + 1, path.lastIndexOf("/"));
+
+        JsonObject granuleFile = new JsonObject();
+        granuleFile.addProperty("name", cnmFile.get("name").getAsString());
+        granuleFile.addProperty("path", url_path);
+        granuleFile.addProperty("url_path", cnmFile.get("uri").getAsString());
         granuleFile.addProperty("size", cnmFile.get("size").getAsLong());
         if (cnmFile.has("checksumType")) {
             granuleFile.addProperty("checksumType", cnmFile.get("checksumType").getAsString());

--- a/src/test/java/gov/nasa/cumulus/CnmToGranuleHandlerTest.java
+++ b/src/test/java/gov/nasa/cumulus/CnmToGranuleHandlerTest.java
@@ -131,4 +131,20 @@ public class CnmToGranuleHandlerTest
 
         assert(expectedJson.equals(outputJson.getAsJsonObject("output")));
     }
+
+    public void testBuildSftpGranuleFile() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File inputJsonFile = new File(classLoader.getResource("sftp_input.json").getFile());
+        File expectedJsonFile = new File(classLoader.getResource("sftp_output.json").getFile());
+
+        String input = new String(Files.readAllBytes(inputJsonFile.toPath()));
+        String expected = new String(Files.readAllBytes(expectedJsonFile.toPath()));
+        JsonObject expectedJson = new JsonParser().parse(expected).getAsJsonObject();
+
+        CnmToGranuleHandler cnmToGranuleHandler = new CnmToGranuleHandler();
+        String output = cnmToGranuleHandler.PerformFunction(input, null);
+        JsonObject outputJson = new JsonParser().parse(output).getAsJsonObject();
+
+        assert(expectedJson.equals(outputJson.getAsJsonObject("output")));
+    }
 }

--- a/src/test/resources/sftp_input.json
+++ b/src/test/resources/sftp_input.json
@@ -1,0 +1,64 @@
+{
+  "input": {
+    "version": "1.5.1",
+    "provider": "PODAAC",
+    "collection": "VIIRS_NPP-NAVO-L2P-v3.0",
+    "submissionTime": "2022-03-09T23:02:25.262061",
+    "identifier": "20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0",
+    "product": {
+      "name": "20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0",
+      "files": [
+        {
+          "type": "data",
+          "uri": "sftp://ops-metis.jpl.nasa.gov/cumulus-test/gds2/NAVO/20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc",
+          "size": 16316733,
+          "name": "20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc"
+        },
+        {
+          "type": "metadata",
+          "uri": "sftp://ops-metis.jpl.nasa.gov/cumulus-test/gds2/NAVO/20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc.md5",
+          "size": 97,
+          "name": "20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc.md5"
+        }
+      ],
+      "dataVersion": "3.0"
+    }
+  },
+  "config": {
+    "collection": {
+      "duplicateHandling": "replace",
+      "files": [
+        {
+          "bucket": "protected",
+          "regex": "^[0-9]{14}-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02\\.0-fv03\\.0\\.nc$",
+          "sampleFileName": "20210101000119-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc",
+          "type": "data"
+        },
+        {
+          "bucket": "public",
+          "regex": "^[0-9]{14}-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02\\.0-fv03\\.0\\.nc\\.md5$",
+          "sampleFileName": "20210101000119-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc.md5",
+          "type": "metadata"
+        },
+        {
+          "bucket": "private",
+          "regex": "^[0-9]{14}-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02\\.0-fv03\\.0\\.cmr\\.json$",
+          "sampleFileName": "20210101000119-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.cmr.json",
+          "type": "metadata"
+        },
+        {
+          "bucket": "protected",
+          "regex": "^[0-9]{14}-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02\\.0-fv03\\.0\\.nc\\.dmrpp$",
+          "sampleFileName": "20210101000119-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc.dmrpp",
+          "type": "metadata"
+        }
+      ],
+      "granuleId": "^[0-9]{14}-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02\\.0-fv03\\.0$",
+      "granuleIdExtraction": "^([0-9]{14}-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02\\.0-fv03\\.0)((\\.nc)|(\\.nc\\.md5)|(\\.cmr\\.json)|(\\.nc\\.dmrpp))?$",
+      "name": "VIIRS_NPP-NAVO-L2P-v3.0",
+      "sampleFileName": "20210101000119-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc",
+      "url_path": "{cmrMetadata.CollectionReference.ShortName}",
+      "version": "3.0"
+    }
+  }
+}

--- a/src/test/resources/sftp_output.json
+++ b/src/test/resources/sftp_output.json
@@ -1,0 +1,25 @@
+{
+  "granules": [
+    {
+      "granuleId": "20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0",
+      "version": "3.0",
+      "dataType": "VIIRS_NPP-NAVO-L2P-v3.0",
+      "files": [
+        {
+          "name": "20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc",
+          "path": "cumulus-test/gds2/NAVO",
+          "url_path": "sftp://ops-metis.jpl.nasa.gov/cumulus-test/gds2/NAVO/20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc",
+          "size": 16316733,
+          "type": "data"
+        },
+        {
+          "name": "20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc.md5",
+          "path": "cumulus-test/gds2/NAVO",
+          "url_path": "sftp://ops-metis.jpl.nasa.gov/cumulus-test/gds2/NAVO/20220111135840-NAVO-L2P_GHRSST-SST1m-VIIRS_NPP-v02.0-fv03.0.nc.md5",
+          "size": 97,
+          "type": "metadata"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## [v1.7.0] - 2022-12-12
### Added
- **PODAAC-4308**
  - Support sftp URI from CNM messages
### Changed
### Deprecated
### Removed
### Fixed
### Security
- **Snyk**
  - upgrade aws-java-sdk-s3@1.12.144 to aws-java-sdk-s3@1.12.176
  - manual import jackson-databind@2.13.2 due to @2.12.3 (which has issues) being pulled in by aws-java-sdk-s3 even after version updates
- **PODAAC-4353**
  - Upgrade jackson-databind as well as aws-java-sdk-s3 for Snyk warnings
  - com.amazonaws:aws-java-sdk-s3@1.12.176 to com.amazonaws:aws-java-sdk-s3@1.12.215