### PR TITLE
Feature/PODAAC-5877: Upgrade to Java 11 and CMA 2.0.3

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '8.0.232'
+          java-version: '11.0.6'
       - uses: gradle/gradle-build-action@v1
         with:
           gradle-version: 8.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
-- **PODAAC-xxxx**
+- **PODAAC-5877**
   - Support java 17
   - SonarQube and Jacoco report
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- **PODAAC-xxxx**
+  - Support java 17
+  - SonarQube and Jacoco report
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - **PODAAC-5877**
-  - Support java 17
+  - Support java 11
   - SonarQube and Jacoco report
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mvn clean verify sonar:sonar \
  -Dsonar.host.url=http://localhost:9000 \
  -Dsonar.token=sqp_6dc05b1aa1f622b45112927d2a0510f209776860
  
-* Makde sure using java 17 and gradle 8.3
+* Makde sure using java 11 and gradle 8.3
 mvn clean dependency:copy-dependencies
 gradle build
 ```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 ## Installation
 
-To build the Lambda code:
-
+To build the Lambda code, Refer to following Confluence page:
+https://wiki.jpl.nasa.gov/pages/viewpage.action?spaceKey=PD&title=SonarQube%2C+Jacoco+and+Java+17+upgrade
 ```shell
+* Build with sonarQube and Jacoco report
+mvn clean verify sonar:sonar \
+ -Dsonar.projectKey=cnm2cma-opensource \
+ -Dsonar.projectName='cnm2cma-opensource' \
+ -Dsonar.host.url=http://localhost:9000 \
+ -Dsonar.token=sqp_6dc05b1aa1f622b45112927d2a0510f209776860
+ 
+* Makde sure using java 17 and gradle 8.3
 mvn clean dependency:copy-dependencies
 gradle build
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.17
+targetCompatibility = 1.17
 
 dependencies {
     implementation fileTree(dir: 'target/dependency/', include: '*.jar')

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
-sourceCompatibility = 1.17
-targetCompatibility = 1.17
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
 
 dependencies {
     implementation fileTree(dir: 'target/dependency/', include: '*.jar')

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.560</version>
+            <version>1.12.565</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -90,8 +90,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,21 @@
             <id>clojars.org</id>
             <url>https://repo.clojars.org</url>
         </repository>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
 
     <dependencies>
-
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -32,12 +42,12 @@
         <dependency>
             <groupId>gov.nasa.earthdata</groupId>
             <artifactId>cumulus-message-adapter</artifactId>
-            <version>1.3.9</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.215</version>
+            <version>1.12.560</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -53,7 +63,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -67,5 +77,76 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.13.4.2</version>
         </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.wordinator.xml2docx.MakeDocx</mainClass>
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <formats>
+                                <format>XML</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.10.0.2594</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Support PODAAC-5877, upgrade to CMA 2.0.3

Ticket: [PODAAC-5877]

### Description

make CNM2CMA cumulus 16 and CMA 2.0.3 compatible.

### Overview of work done

Upgrade to make use of CMA 2.0.3
Java 11
dependency cumulus-message-adapter 1.3.9 -> 2.0.0


### Overview of verification done

Download the github action build artifact, un-zip and use 

javap -verbose XXXX.class 
to verify the compiled class file is at version 55, which is java11.

Integration testing with MetadataAggregator and CNMResponse

#### Tested in SIT:

_Explain how you tested in SIT, if applicable_

## PR checklist:

* [ ] Linted
* [] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
