### PR TITLE
Add the "fileName" and "key" properties as listed in the later version of the cumulus granule file schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1]
+### Added
+- **User contribution**
+  - Add the "fileName" and "key" properties to the granuleFile object from buildS3GranuleFile function
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [1.8.0]
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.1]
+## [1.8.0]
 ### Added
 - **User contribution**
   - Add the "fileName" and "key" properties to the granuleFile object from buildS3GranuleFile function
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
-
-## [1.8.0]
-### Added
 ### Changed
 - **PODAAC-5877**
   - Support java 11

--- a/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
+++ b/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
@@ -209,6 +209,7 @@ public class CnmToGranuleHandler implements ITask, RequestHandler<String, String
         }
         granuleFile.addProperty("type", cnmFile.get("type").getAsString());
         granuleFile.addProperty("fileName", cnmFile.get("name").getAsString());
+        granuleFile.addProperty("key", url_path);
         return granuleFile;
     }
 

--- a/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
+++ b/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
@@ -209,7 +209,7 @@ public class CnmToGranuleHandler implements ITask, RequestHandler<String, String
         }
         granuleFile.addProperty("type", cnmFile.get("type").getAsString());
         granuleFile.addProperty("fileName", cnmFile.get("name").getAsString());
-        granuleFile.addProperty("key", url_path);
+        granuleFile.addProperty("key", url_path + '/' + cnmFile.get("name").getAsString());
         return granuleFile;
     }
 

--- a/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
+++ b/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
@@ -208,6 +208,8 @@ public class CnmToGranuleHandler implements ITask, RequestHandler<String, String
             granuleFile.addProperty("checksum", cnmFile.get("checksum").getAsString());
         }
         granuleFile.addProperty("type", cnmFile.get("type").getAsString());
+
+        // Add the "fileName" and "key" properties as listed in the later version of the cumulus granule file schema
         granuleFile.addProperty("fileName", cnmFile.get("name").getAsString());
         granuleFile.addProperty("key", url_path + '/' + cnmFile.get("name").getAsString());
         return granuleFile;

--- a/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
+++ b/src/main/java/gov/nasa/cumulus/CnmToGranuleHandler.java
@@ -208,6 +208,7 @@ public class CnmToGranuleHandler implements ITask, RequestHandler<String, String
             granuleFile.addProperty("checksum", cnmFile.get("checksum").getAsString());
         }
         granuleFile.addProperty("type", cnmFile.get("type").getAsString());
+        granuleFile.addProperty("fileName", cnmFile.get("name").getAsString());
         return granuleFile;
     }
 


### PR DESCRIPTION
This PR will add the "fileName" and "key" properties as listed in [the later version of the cumulus granule file schema](https://github.com/nasa/cumulus/blob/master/packages/schemas/files.schema.json).

The reason for this is to fulfill the input requirements of the `dmrpp-generator` task. We have a CNM-based workflow beginning with the `dmrpp-generator`. However, this process failed because the required properties "fileName" and "key" were absent from the output of `cumulus-cnm-to-granule`.

More detailed slack conversation can be found from [here](https://eosdis.slack.com/archives/C76M787MZ/p1675362167340409).

Note that this PR only modified the `buildS3GranuleFile` function and did not make any changes to existing tests, because the current testing suite doesn't have tests for the `buildS3GranuleFile` function.