### PR TITLE
Enable Snyk test in Github Actions workflow

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: gradle/gradle-build-action@v1
         with:
           gradle-version: 8.0.1
+          distributions-cache-enabled: false
+          wrapper-cache-enabled: false
       - name: Install Python 3
         uses: actions/setup-python@v2
         with:
@@ -81,6 +83,13 @@ jobs:
         run: |
           echo "New Version is: ${{ env.software_version }}"
           python3 builder/builder2.py -d . -a ${{env.ARTIFACT_BASE_NAME}} -v ${{ env.software_version }}
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+      - name: Snyk Security Scan
+        run: snyk test --all-sub-projects --package-manager=gradle --file=build.gradle
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TIMEOUT_SECS: 90
       - name: Prepare Artifacts
         run: |
           artifact_file_name="${{ env.ARTIFACT_BASE_NAME }}-${{ env.software_version }}.zip"


### PR DESCRIPTION
## Overview
- Same implementation as repo cumulus-cnm-response-task
- Runs Snyk tests when any commits are pushed to branches `develop, release/**, feature/**, master, main`

## Updates
- Adds github action step to install Snyk CLI to run the snyk test command. This was done since running the Snyk CLI commands will leverage the JAVA environment that was already built in previous steps.
- Adds github action step to run the Snyk test using the CLI command. Adds a 90 second timeout in case the CLI test scan hangs.
- Updates gradle build step to disable the cache since a network issue was preventing access to the cache which failed the build step. The build step takes ~10 seconds with the cache disabled.

### Github Action Build

https://github.com/podaac/cumulus-cnm-to-granule/actions/runs/15404212571/job/43343524003